### PR TITLE
fix: sort form fields by created order

### DIFF
--- a/frontend/src/components/Forms/NewPatientForm/generateForm.tsx
+++ b/frontend/src/components/Forms/NewPatientForm/generateForm.tsx
@@ -50,14 +50,18 @@ function GenerateForm(props: GenerateFormProps) {
   const history = useHistory();
 
   const [fields, setFields] = useState(data.fields.sort((a, b) => {
-    if (a.type < b.type) {
-      return -1;
+    if (a.id && b.id) {
+      if (a.id < b.id!) {
+        return -1;
+      }
+      if (a.id > b.id) {
+        return 1;
+      }
+      return 0;
     }
-    if (a.type > b.type) {
-      return 1;
-    }
+    console.error('Form ids not obtained. Defaulting to standard order');
     return 0;
-  }).reverse());
+  }));
   useEffect(() => {
     setFields(data.fields);
   }, []);
@@ -116,11 +120,9 @@ function GenerateForm(props: GenerateFormProps) {
       type: data.type,
       fields,
     };
-    console.log(patientForm);
     setLoading(true);
     try {
       await registerPatientForm(id, patientForm);
-      // TODO: Redireccionar a el detail de la pagina
       toast.success('Se han llenado los datos de la encuesta exitosamente.');
       history.replace(`/expediente/${id}`);
     } catch (error) {

--- a/frontend/src/views/Forms/updatePatientForm.tsx
+++ b/frontend/src/views/Forms/updatePatientForm.tsx
@@ -22,6 +22,7 @@ import { updatePatientForm, getFormField } from 'src/api/forms';
 import LoadingSpinner from 'src/components/loadingSpinner';
 import { toast } from 'react-toastify';
 import { useHistory, useParams } from 'react-router';
+import PatientFormField from 'src/interfaces/patientFormField';
 
 const useStyles = makeStyles((theme) => ({
   heroContent: {
@@ -55,7 +56,21 @@ function UpdatePatientForm() {
   useEffect(() => {
     getFormField(formId)
       .then((response:any) => {
-        setFields(Object.values(response.data.fields));
+        setFields(Object.values(response.data.fields.sort(
+          (a: PatientFormField, b: PatientFormField) => {
+            if (a.id && b.id) {
+              if (a.id < b.id!) {
+                return -1;
+              }
+              if (a.id > b.id) {
+                return 1;
+              }
+              return 0;
+            }
+            console.error('Form ids not obtained. Defaulting to standard order');
+            return 0;
+          },
+        )));
         setFormInformation(response.data);
       })
       .catch((error:any) => console.log(error));


### PR DESCRIPTION
#### ¿Qué hace este PR?
Arregla el defecto 39 para que los campos de un form lleguen en el orden adecuado.

#### ¿Cómo debería ser probado manualmente?
Creando un form y registrándose a un paciente. Los campos deben llegar en el mismo orden que en la vista de registrar el tipo de form.

#### ¿Algún background que desees proveer?
El ordenamiento actualmente se está haciendo con el id del field, el cual es autoincremental y garantiza que llegue en el orden de creación. Sin este ordenamiento, el backend no regresa en orden exacto de creación. 


#### Screenshots
![image](https://user-images.githubusercontent.com/38927620/118757744-4d05ca00-b833-11eb-996d-67e32424a7ca.png)
