### PR TITLE
fix: Botón duplicado de editar y SWAL con errores de ortografía

### DIFF
--- a/frontend/src/views/Users/viewUsers.tsx
+++ b/frontend/src/views/Users/viewUsers.tsx
@@ -106,10 +106,11 @@ function ViewUsers() {
       <TableCell>{user.zipCode}</TableCell>
       <TableCell>{user.address}</TableCell>
       <TableCell>
-        <IconButton data-userid={user.username} onClick={updateProfile}>
-          <Edit color="secondary" />
-        </IconButton>
-        <IconButton disabled={!user.active || !(user.id !== currentUser.user.id)}>
+        <IconButton
+          disabled={!user.active || !(user.id !== currentUser.user.id)}
+          data-userid={user.username}
+          onClick={updateProfile}
+        >
           <Edit color={(user.active && (user.id !== currentUser.user.id)) ? 'secondary' : 'disabled'} />
         </IconButton>
       </TableCell>
@@ -161,4 +162,5 @@ function ViewUsers() {
     </main>
   );
 }
+
 export default ViewUsers;

--- a/frontend/src/views/Users/viewUsers.tsx
+++ b/frontend/src/views/Users/viewUsers.tsx
@@ -47,7 +47,7 @@ function ViewUsers() {
       await deactivateAccount(id);
       Swal.fire(
         '¡Cuenta desactivada!',
-        'El usuario no podrá acceder al sistema a partir de este momento.',
+        'El usuario no tiene acceso al sistema a partir de este momento.',
         'success',
       );
     } catch (error) {
@@ -67,7 +67,7 @@ function ViewUsers() {
   function handleDelete(id:number) {
     Swal.fire({
       title: '¿Está seguro de desactivar al usuario?',
-      text: 'Al confrimar, el usuario no podrá acceder al sistema.',
+      text: 'Al confirmar, el usuario no tendrá acceso al sistema.',
       icon: 'warning',
       showCancelButton: true,
       cancelButtonText: 'Cancelar',

--- a/frontend/src/views/Users/viewUsers.tsx
+++ b/frontend/src/views/Users/viewUsers.tsx
@@ -66,7 +66,7 @@ function ViewUsers() {
 
   function handleDelete(id:number) {
     Swal.fire({
-      title: '¿Está seguro de desactivar al usuario?',
+      title: '¿Desactivar usuario?',
       text: 'Al confirmar, el usuario no tendrá acceso al sistema.',
       icon: 'warning',
       showCancelButton: true,

--- a/frontend/src/views/Users/viewUsers.tsx
+++ b/frontend/src/views/Users/viewUsers.tsx
@@ -46,15 +46,15 @@ function ViewUsers() {
     try {
       await deactivateAccount(id);
       Swal.fire(
-        'Cuenta desactivada!',
-        'El usuario no podrá acceder a partir de este momento.',
+        '¡Cuenta desactivada!',
+        'El usuario no podrá acceder al sistema a partir de este momento.',
         'success',
       );
     } catch (error) {
       Swal.fire({
         icon: 'error',
         title: 'Oops...',
-        text: 'Ocurrio un error interno!',
+        text: '¡Ocurrió un error interno!',
       });
       console.log(error);
     } finally {
@@ -66,8 +66,8 @@ function ViewUsers() {
 
   function handleDelete(id:number) {
     Swal.fire({
-      title: '¿Estás seguro de desactivar al usuario?',
-      text: 'El usuario no podrá acceder al sistema',
+      title: '¿Está seguro de desactivar al usuario?',
+      text: 'Al confrimar, el usuario no podrá acceder al sistema.',
       icon: 'warning',
       showCancelButton: true,
       cancelButtonText: 'Cancelar',


### PR DESCRIPTION
#### ¿Qué hace este PR?
Correcciones en vista de view-users

#### ¿Cómo debería ser probado manualmente?
* **Botón editar** -  Hacer uso del botón de editar usuario.
*  **SWAL** - Desactivar usuario

#### ¿Algún background que desees proveer? 
Había unas faltas de ortografía y el botón de editar estaba dos veces y con sus funcionalidades divididas entre los dos.

#### Screenshots

**Botón** Antes se veía así la vista
<img width="1020" alt="Screen Shot 2021-05-26 at 23 35 07" src="https://user-images.githubusercontent.com/48339576/119769780-b95e7a00-be80-11eb-8a15-3a3d1ebe392c.png">

Ahora así
<img width="986" alt="Screen Shot 2021-05-27 at 0 16 14" src="https://user-images.githubusercontent.com/48339576/119769809-c8452c80-be80-11eb-9949-ccd0719b4383.png">

El SWAL no tengo SS del antes pero así quedó
<img width="394" alt="Screen Shot 2021-05-27 at 0 26 59" src="https://user-images.githubusercontent.com/48339576/119770816-5372f200-be82-11eb-84dc-5c82e8ab30e2.png">


